### PR TITLE
Only run test workflow once per PR

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,5 +1,5 @@
 name: Python unit tests
-on: [push, pull_request]
+on: [push]
 jobs:
   run-tests:
     runs-on: "ubuntu-20.04"


### PR DESCRIPTION
Running it on push and on PR meant it runs twice. The documentation is very dense, but I think this is the right way to do it. The action types for PRs don't really make any sense for this project.